### PR TITLE
한글패치 커뮤 추출 / 백그라운드 BGM 기능 관련 수정

### DIFF
--- a/src/transKR/inject.js
+++ b/src/transKR/inject.js
@@ -1,59 +1,54 @@
-var GMOptions = [];
+var GMOptions = {};
 
 function Inject_GM_registerMenuCommand(commandName, commandFunc, accessKey) {
-	console.log(commandName);
-	console.log(commandFunc);
-	console.log(accessKey);
-	let index = GMOptions.findIndex((value)=>{
-		value.commandName == commandName
-	});
-	if(index === -1) {
-		index = GMOptions.length;
-	}
-	GMOptions[index] = {
-		commandName: commandName,
-		commandFunc: commandFunc,
-		accessKey: accessKey
-	};
-	if(commandName.includes("백그라운드 BGM")) {
-		GMOptions[index].action = "background-bgm";
-		if(window.parentDocument) {
-			window.parentDocument.querySelector(".button-transKR.background-bgm").textContent = commandName;
-			window.parentDocument.querySelector(".button-transKR.background-bgm").onclick = commandFunc;
-		}
-	} else if(commandName.includes("커뮤 추출")) {
-		GMOptions[index].action = "commu-extract";
-		if(window.parentDocument) {
-			window.parentDocument.querySelector(".button-transKR.commu-extract").textContent = commandName;
-			window.parentDocument.querySelector(".button-transKR.commu-extract").onclick = commandFunc;
-		}
-	}
-	return index;
+    console.log(commandName);
+    console.log(commandFunc);
+    console.log(accessKey);
+
+    // Ignore accessKey - it's for shortcuts to menus but we won't use it
+    GMOptions[commandName] = {
+        commandName: commandName,
+        commandFunc: commandFunc,
+    };
+
+    if (commandName.includes("백그라운드 BGM")) {
+        GMOptions[commandName].action = "background-bgm";
+        if (window.parentDocument) {
+            window.parentDocument.querySelector(".button-transKR.background-bgm").textContent = commandName;
+            window.parentDocument.querySelector(".button-transKR.background-bgm").onclick = commandFunc;
+        }
+    } else if (commandName.includes("커뮤 추출")) {
+        GMOptions[commandName].action = "commu-extract";
+        if (window.parentDocument) {
+            window.parentDocument.querySelector(".button-transKR.commu-extract").textContent = commandName;
+            window.parentDocument.querySelector(".button-transKR.commu-extract").onclick = commandFunc;
+        }
+    }
+    return commandName;
 }
 
 function Inject_GM_unregisterMenuCommand(menuCmdId) {
-	console.log(menuCmdId);
-	if(GMOptions[menuCmdId]) {
-		var GMOption = GMOptions.splice(menuCmdId,1); 
-	}
+    console.log(menuCmdId);
+    if (GMOptions[menuCmdId]) {
+        delete GMOptions[menuCmdId]
+    }
 }
 
-if(typeof nw !== 'undefined') {
-	var win = nw.window.get().window;
+if (typeof nw !== 'undefined') {
+    var win = nw.window.get().window;
 } else {
-	var win = window;
+    var win = window;
 }
-if(win.location.hostname.indexOf("shinycolors.enza.fun") != -1) {
-	win.GM_registerMenuCommand = Inject_GM_registerMenuCommand;
-	win.GM_unregisterMenuCommand = Inject_GM_unregisterMenuCommand;
-	var interval = setInterval(function () {
-		if (typeof win.parentDocument !== 'undefined')
-		{
-			clearInterval(interval);
-			win.parentDocument.querySelector(".button-transKR.background-bgm").textContent = GMOptions.find((value)=>value.action == "background-bgm").commandName;
-			win.parentDocument.querySelector(".button-transKR.background-bgm").onclick = GMOptions.find((value)=>value.action == "background-bgm").commandFunc;
-			win.parentDocument.querySelector(".button-transKR.commu-extract").textContent = GMOptions.find((value)=>value.action == "commu-extract").commandName;
-			win.parentDocument.querySelector(".button-transKR.commu-extract").onclick = GMOptions.find((value)=>value.action == "commu-extract").commandFunc;
-		}
-	});
+if (win.location.hostname.indexOf("shinycolors.enza.fun") != -1) {
+    win.GM_registerMenuCommand = Inject_GM_registerMenuCommand;
+    win.GM_unregisterMenuCommand = Inject_GM_unregisterMenuCommand;
+    var interval = setInterval(function() {
+        if (typeof win.parentDocument !== 'undefined') {
+            clearInterval(interval);
+            win.parentDocument.querySelector(".button-transKR.background-bgm").textContent = Object.values(GMOptions).find((value) => value.action == "background-bgm").commandName;
+            win.parentDocument.querySelector(".button-transKR.background-bgm").onclick = Object.values(GMOptions).find((value) => value.action == "background-bgm").commandFunc;
+            win.parentDocument.querySelector(".button-transKR.commu-extract").textContent = Object.values(GMOptions).find((value) => value.action == "commu-extract").commandName;
+            win.parentDocument.querySelector(".button-transKR.commu-extract").onclick = Object.values(GMOptions).find((value) => value.action == "commu-extract").commandFunc;
+        }
+    });
 }

--- a/src/transKR/inject.js
+++ b/src/transKR/inject.js
@@ -1,54 +1,54 @@
 var GMOptions = {};
 
 function Inject_GM_registerMenuCommand(commandName, commandFunc, accessKey) {
-    console.log(commandName);
-    console.log(commandFunc);
-    console.log(accessKey);
+	console.log(commandName);
+	console.log(commandFunc);
+	console.log(accessKey);
 
-    // Ignore accessKey - it's for shortcuts to menus but we won't use it
-    GMOptions[commandName] = {
-        commandName: commandName,
-        commandFunc: commandFunc,
-    };
-
-    if (commandName.includes("백그라운드 BGM")) {
-        GMOptions[commandName].action = "background-bgm";
-        if (window.parentDocument) {
-            window.parentDocument.querySelector(".button-transKR.background-bgm").textContent = commandName;
-            window.parentDocument.querySelector(".button-transKR.background-bgm").onclick = commandFunc;
-        }
-    } else if (commandName.includes("커뮤 추출")) {
-        GMOptions[commandName].action = "commu-extract";
-        if (window.parentDocument) {
-            window.parentDocument.querySelector(".button-transKR.commu-extract").textContent = commandName;
-            window.parentDocument.querySelector(".button-transKR.commu-extract").onclick = commandFunc;
-        }
-    }
-    return commandName;
+	// Ignore accessKey - it's for shortcuts to menus but we won't use it
+	GMOptions[commandName] = {
+		commandName: commandName,
+		commandFunc: commandFunc,
+	};
+	
+	if (commandName.includes("백그라운드 BGM")) {
+		GMOptions[commandName].action = "background-bgm";
+		if (window.parentDocument) {
+			window.parentDocument.querySelector(".button-transKR.background-bgm").textContent = commandName;
+			window.parentDocument.querySelector(".button-transKR.background-bgm").onclick = commandFunc;
+		}
+	} else if (commandName.includes("커뮤 추출")) {
+		GMOptions[commandName].action = "commu-extract";
+		if (window.parentDocument) {
+			window.parentDocument.querySelector(".button-transKR.commu-extract").textContent = commandName;
+			window.parentDocument.querySelector(".button-transKR.commu-extract").onclick = commandFunc;
+		}
+	}
+	return commandName;
 }
 
 function Inject_GM_unregisterMenuCommand(menuCmdId) {
-    console.log(menuCmdId);
-    if (GMOptions[menuCmdId]) {
-        delete GMOptions[menuCmdId]
-    }
+	console.log(menuCmdId);
+	if (GMOptions[menuCmdId]) {
+		delete GMOptions[menuCmdId]
+	}
 }
 
 if (typeof nw !== 'undefined') {
-    var win = nw.window.get().window;
+	var win = nw.window.get().window;
 } else {
-    var win = window;
+	var win = window;
 }
 if (win.location.hostname.indexOf("shinycolors.enza.fun") != -1) {
-    win.GM_registerMenuCommand = Inject_GM_registerMenuCommand;
-    win.GM_unregisterMenuCommand = Inject_GM_unregisterMenuCommand;
-    var interval = setInterval(function() {
-        if (typeof win.parentDocument !== 'undefined') {
-            clearInterval(interval);
-            win.parentDocument.querySelector(".button-transKR.background-bgm").textContent = Object.values(GMOptions).find((value) => value.action == "background-bgm").commandName;
-            win.parentDocument.querySelector(".button-transKR.background-bgm").onclick = Object.values(GMOptions).find((value) => value.action == "background-bgm").commandFunc;
-            win.parentDocument.querySelector(".button-transKR.commu-extract").textContent = Object.values(GMOptions).find((value) => value.action == "commu-extract").commandName;
-            win.parentDocument.querySelector(".button-transKR.commu-extract").onclick = Object.values(GMOptions).find((value) => value.action == "commu-extract").commandFunc;
-        }
-    });
+	win.GM_registerMenuCommand = Inject_GM_registerMenuCommand;
+	win.GM_unregisterMenuCommand = Inject_GM_unregisterMenuCommand;
+	var interval = setInterval(function() {
+		if (typeof win.parentDocument !== 'undefined') {
+			clearInterval(interval);
+			win.parentDocument.querySelector(".button-transKR.background-bgm").textContent = Object.values(GMOptions).find((value) => value.action == "background-bgm").commandName;
+			win.parentDocument.querySelector(".button-transKR.background-bgm").onclick = Object.values(GMOptions).find((value) => value.action == "background-bgm").commandFunc;
+			win.parentDocument.querySelector(".button-transKR.commu-extract").textContent = Object.values(GMOptions).find((value) => value.action == "commu-extract").commandName;
+			win.parentDocument.querySelector(".button-transKR.commu-extract").onclick = Object.values(GMOptions).find((value) => value.action == "commu-extract").commandFunc;
+		}
+	});
 }


### PR DESCRIPTION
배열 사용 시 한글패치가 메뉴를 업데이트하는 방식 때문에 버튼들이 한번만 작동하고 그 이후로는 작동하지 않았을 거라고 생각함.

우선 기존 코드대로 한글패치 구동 시 초기에 업데이트 - BGM - 커뮤 추출 메뉴 순으로 배열에 등록이 됨.
```none
index 0: { commandName: "업데이트", ... }
index 1: { commandName: "백그라운드 BGM 켜기"}
index 2: { commandName: "커뮤 추출 켜기" }
```
메뉴 하나가 선택되면 한패에서 등록되었던 메뉴들을 하나씩 제거하고 다시 등록하는데, 여기서 id = index이기에 문제가 생김. 업데이트 메뉴 (index 0) 삭제 후 재 등록 - BGM 메뉴 (index 1) 삭제 후 재 등록 - 커뮤 추출 메뉴 (index 2) 삭제 후 재 등록의 순서로 이루어지는데, 앞의 메뉴가 배열에서 삭제되고 새 메뉴가 배열의 맨 뒤에 추가되므로 뒤의 메뉴 두 개의 실질적 ID가 바뀌는 문제가 있음.

예시 (백그라운드 BGM 켜기 메뉴를 선택한 경우)
```none
초기
index 0: { commandName: "업데이트" }
index 1: { commandName: "백그라운드 BGM 켜기"}
index 2: { commandName: "커뮤 추출 켜기" }

ID 0 (업데이트) 삭제 후
index 0: { commandName: "백그라운드 BGM 켜기"}
index 1: { commandName: "커뮤 추출 켜기" }

업데이트 메뉴 등록 후
index 0: { commandName: "백그라운드 BGM 켜기"}
index 1: { commandName: "커뮤 추출 켜기" }
index 2: { commandName: "업데이트" }

ID 1 (원래 백그라운드 BGM 켜기였으나, 지금은 커뮤 추출이 됨) 삭제 후
index 0: { commandName: "백그라운드 BGM 켜기"}
index 1: { commandName: "업데이트" }

백그라운드 BGM 끄기 등록 후
index 0: { commandName: "백그라운드 BGM 켜기" }
index 1: { commandName: "업데이트" }
index 2: { commandName: "백그라운드 BGM 끄기" }

ID 2 삭제 후 (원래 커뮤 추출 켜기였으나, 지금은 백그라운드 BGM 끄기가 됨)
index 0: { commandName: "백그라운드 BGM 켜기" }
index 1: { commandName: "업데이트" }

커뮤 추출 켜기 등록 후
index 0: { commandName: "백그라운드 BGM 켜기" }
index 1: { commandName: "업데이트" }
index 2: { commandName: "커뮤 추출 켜기" }
```

개인적으로 실행기를 사용하지는 않아서 직접 테스트해보지는 못했는데, 제보에 따르면 실제로 작동 안 한다는 것 같고, 직접 실행기 만드는 과정에서 코드를 참조했었는데 뭔가 작동을 안 하길래 디버깅하다 발견한 것임.

ID로 `commandName` 직접 사용하게 수정하고 (문제가 될 지는 모르겠음? Tampermonkey에서도 ID 자체는 string으로 반환하니 data type 관련해서 문제는 없을 것 같음) array 대신 object 사용하게 코드를 바꿔는 놨는데, 아무래도 `registerMenuCommand` 함수에서 `commandName`이 한패나 커뮤면 버튼 이벤트 핸들러를 바꾸는 부분이 있다보니 이게 과연 정말로 해당 버그랑 관련이 있는지는 의문이기는 한데 그래도 일단 뭔가 오작동하는 부분이니까 고쳐는 놨음.